### PR TITLE
tests: add info command handler test

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,7 +1,23 @@
 import { expect } from '@jest/globals'
+import { ArgumentsCamelCase, Argv } from 'yargs'
+
+import { commands } from './commands';
 
 describe('First Test Case', () => {
   it('should pass', () => {
     expect(true).toBeTruthy()
+  })
+
+  it('command "info" defined and does not throw', () => {
+    const args = {
+      _: [ 'info' ],
+      group: true,
+      g: true,
+      '$0': 'bin/run.ts'
+    };
+    expect(commands[0]).toBeDefined();
+    expect(() => {
+      commands[0]?.handler(args as unknown as ArgumentsCamelCase<Argv>)
+    }).not.toThrow();
   })
 })


### PR DESCRIPTION
Simple test that adds some sanity checks into sample command:

- command `info` is defined
- the handler does not throw when involved

Make sure that all imports are proper, and that the `logger` is OK.